### PR TITLE
Update terraform provider versions to the most recent

### DIFF
--- a/domain.tf
+++ b/domain.tf
@@ -98,7 +98,7 @@ resource "aws_cloudfront_distribution" "main" {
   default_root_object = "index.html"
 
   origin {
-    domain_name = aws_s3_bucket.files.website_endpoint
+    domain_name = aws_s3_bucket_website_configuration.files.website_endpoint
     origin_id   = "origin-${var.domain_name}"
     custom_origin_config {
       http_port              = 80

--- a/main.tf
+++ b/main.tf
@@ -2,16 +2,16 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0.0"
+      version = "~> 5.89.0"
       configuration_aliases = [ aws.acm ]
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1.0"
+      version = "~> 3.7.1"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.2.0"
+      version = "~> 2.7.0"
     }
   }
   required_version = "~> 1.0"

--- a/wwwredirect.tf
+++ b/wwwredirect.tf
@@ -79,7 +79,7 @@ resource "aws_cloudfront_distribution" "www" {
   origin {
     connection_attempts = 3
     connection_timeout  = 10
-    domain_name         = aws_s3_bucket.www.website_endpoint
+    domain_name         = aws_s3_bucket_website_configuration.files.website_endpoint
     origin_id           = aws_s3_bucket.www.id
 
     custom_origin_config {


### PR DESCRIPTION
I have confirmed that deploying an existing project with these updates works. You will need to run "init --upgrade" when redeploying an existing project.

Deploying a new project with these fixes the dependency issue that causes the first run to fail and requiring a second run.