### PR TITLE
Content type fix for mjs

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -73,16 +73,17 @@ module "template_files" {
   base_dir = var.dist_folder
   depends_on = [local_file.robots-txt]
 }
-locals {
-  content_type_overrides = {
-    "apple-app-site-association" = "application/json"
-  }
-}
+
 resource "aws_s3_object" "app_storage" {
   for_each     = module.template_files.files
   bucket       = aws_s3_bucket.files.id
   key          = each.key
-  content_type = lookup(local.content_type_overrides, regex("[^\\/\\\\]+$", each.value.source_path), each.value.content_type)
+
+  content_type = (
+    can(regex("\\.mjs$", each.value.source_path)) ? "application/javascript" :
+    regex("[^\\/\\\\]+$", each.value.source_path) == "apple-app-site-association" ? "application/json" :
+    each.value.content_type
+  )
 
   # The template_files module guarantees that only one of these two attributes
   # will be set for each file, depending on whether it is an in-memory template


### PR DESCRIPTION
.mjs files default to having a content type of `application/octet-stream` in S3 unless another content type is specified. But the content type needs to be `application/javascript` in order for the browser to recognize it as valid js and run it.